### PR TITLE
Compress the man page with gzip -n

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build:
 	@echo "Building${TAGS_ARGS}..."
 	@mkdir -p dist
 	@go build ${TAGS_ARGS} -o dist/${DISTFILE} -ldflags "-X github.com/tvrzna/emptty/src.buildVersion=${BUILD_VERSION}"
-	@gzip -c res/emptty.1 > dist/emptty.1.gz
+	@gzip -cn res/emptty.1 > dist/emptty.1.gz
 	@echo "Done"
 
 install:


### PR DESCRIPTION
Hi,
I'm maintaining the [emptty](https://aur.archlinux.org/packages/emptty) package on AUR and unfortunately it's not [reproducible](https://reproducible-builds.org/) because embedded timestamps of manpages are changing between builds.

```
--- emptty-0.4.2-2-x86_64.pkg.tar.zst
+++ ./build/emptty-0.4.2-2-x86_64.pkg.tar.zst
├── emptty-0.4.2-2-x86_64.pkg.tar
│ ├── file list
│ │ @@ -1,9 +1,9 @@
│ │  -rw-r--r--   0 root         (0) root         (0)     4503 2020-12-11 17:22:35.000000 .BUILDINFO
│ │ --rw-r--r--   0 root         (0) root         (0)      900 2020-12-11 17:22:35.000000 .MTREE
│ │ +-rw-r--r--   0 root         (0) root         (0)      903 2020-12-11 17:22:35.000000 .MTREE
│ │  -rw-r--r--   0 root         (0) root         (0)      607 2020-12-11 17:22:35.000000 .PKGINFO
│ │  drwxr-xr-x   0 root         (0) root         (0)        0 2020-12-11 17:22:35.000000 etc/
│ │  drwxr-xr-x   0 root         (0) root         (0)        0 2020-12-11 17:22:35.000000 etc/emptty/
│ │  -rw-r--r--   0 root         (0) root         (0)     1426 2020-12-11 17:22:35.000000 etc/emptty/conf
│ │  drwxr-xr-x   0 root         (0) root         (0)        0 2020-12-11 17:22:35.000000 etc/pam.d/
│ │  -rw-r--r--   0 root         (0) root         (0)      267 2020-12-11 17:22:35.000000 etc/pam.d/emptty
│ │  drwxr-xr-x   0 root         (0) root         (0)        0 2020-12-11 17:22:35.000000 usr/
│ ├── .MTREE
│ │ ├── .MTREE-content
│ │ │ @@ -20,8 +20,8 @@
│ │ │  ./usr/share/doc/emptty time=1607707355.0 type=dir
│ │ │  ./usr/share/doc/emptty/README.md time=1607707355.0 mode=644 size=7815 md5digest=98c1663f97bd909ce804079fbf5a1974 sha256digest=ef770733b563f20525460e04733b8f2df2698e45c9e204722a9d72eb473a1325
│ │ │  ./usr/share/licenses time=1607707355.0 type=dir
│ │ │  ./usr/share/licenses/emptty time=1607707355.0 type=dir
│ │ │  ./usr/share/licenses/emptty/LICENSE time=1607707355.0 mode=644 size=1063 md5digest=d1e4d12c7d1d17367ba5668706a405ba sha256digest=01c89447800662c0a5d158669a2a03d07b36b79f14bc559c9fca3b51961946b6
│ │ │  ./usr/share/man time=1607707355.0 type=dir
│ │ │  ./usr/share/man/man1 time=1607707355.0 type=dir
│ │ │ -./usr/share/man/man1/emptty.1.gz time=1607707355.0 size=2340 md5digest=e773cf9ebc5a2d8a9d16a7ef368d7d96 sha256digest=4be90213843005fbdc27f0b1381298964cb4c1a14e956b4f5b8328ccdbaba5c3
│ │ │ +./usr/share/man/man1/emptty.1.gz time=1607707355.0 size=2340 md5digest=3e8bd64ae13a5f74aaa636a5ef3320c7 sha256digest=ebf67e84012a0bf4f7022174d0fed470d7ee6a4c6d963a2512af80508288fd97
│ ├── usr/share/man/man1/emptty.1.gz
│ │ ├── filetype from file(1)
│ │ │ @@ -1 +1 @@
│ │ │ -gzip compressed data, was "emptty.1", last modified: Fri Dec  4 06:25:16 2020, from Unix
│ │ │ +gzip compressed data, was "emptty.1", last modified: Fri Dec 11 17:22:35 2020, from Unix

```

This PR proposes to add `-n` flag to `gzip` command in Makefile to make package reproducible:

```
-n --no-name
      When  compressing, do not save the original file name and timestamp by default. (The original name is always saved if the name had to be truncated.) When decompressing, do not
      restore the original file name if present (remove only the gzip suffix from the compressed file name) and do not restore the original timestamp if present (copy  it  from  the
      compressed file). This option is the default when decompressing.
```