### PR TITLE
openrc-service: start after local and before getty

### DIFF
--- a/res/openrc-service
+++ b/res/openrc-service
@@ -5,3 +5,8 @@ command=/usr/bin/emptty
 command_args="-d"
 pidfile="/run/${RC_SVCNAME}.pid"
 respawn_period=${respawn_period-60}
+
+depend() {
+  after local
+  before getty
+}


### PR DESCRIPTION
A GUI environment started by emptty may depend on anything started before local. If emptty starts after getty, getty prompt is polluted by openrc's emptty startup message.