### PR TITLE
Accept TTY name parameter for `--tty`

### DIFF
--- a/res/emptty.1
+++ b/res/emptty.1
@@ -26,7 +26,7 @@ Loads configuration from specified path.
 Skips loading of configuration from file, loads only argument configuration.
 
 .IP "\-t, \-\-tty TTY"
-Overrides loaded configuration by setting defined TTY.
+Overrides loaded configuration by setting defined TTY. May be specified as a number (e.g. "7") or a TTY name (e.g. "tty7").
 
 .IP "\-u, \-\-default-user defaultUser"
 Overrides loaded configuration by setting defined defaultUser.

--- a/src/emptty.go
+++ b/src/emptty.go
@@ -111,6 +111,14 @@ func processArgs(args []string, conf *config) {
 				tty := parseTTY(val, "0")
 				if tty > 0 {
 					conf.Tty = tty
+				} else {
+					ttynum := strings.SplitAfterN(val, "tty", 2)
+					if len(ttynum) == 2 {
+						tty := parseTTY(ttynum[1], "0")
+						if tty > 0 {
+							conf.Tty = tty
+						}
+					}
 				}
 			})
 		case "-u", "--default-user":


### PR DESCRIPTION
This commit adds a `--tty-name` command-line argument for specifying the TTY by name, e.g. `tty7` instead of just `7`.

This may be a little superfluous since `--tty` already exists, but it allows using a systemd template unit something like the following without using a bare number for the instance name (similar to how the getty unit instances are named `getty@tty1.service`, etc.):

```ini
# /lib/systemd/system/emptty@.service
[Unit]
Description=emptty display manager on %I
Documentation=man:emptty(1)
After=systemd-user-sessions.service plymouth-quit-wait.service
After=getty@%i.service display-manager.service
Conflicts=getty@%i.service display-manager.service
ConditionPathExists=/dev/%I

[Service]
Type=idle
EnvironmentFile=-/etc/emptty/conf.%I
ExecStart=/usr/bin/emptty --daemon --tty-name %I
Restart=always
KillMode=process
IgnoreSIGPIPE=no
SendSIGHUP=yes
TTYPath=/dev/%I
TTYReset=yes
TTYVHangup=yes
TTYVTDisallocate=yes
```

Then one can do `systemctl start emptty@tty7.service`, `systemctl start emptty@tty8.service`, etc. to create multiple instances of the `emptty` service for several terminals.

Thanks!