### PR TITLE
docs: fix Selection=auto value docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ See [samples](SAMPLES.md#emptty-as-config)
 
 `Lang` Defines locale for logged user, has higher priority than LANG from global configuration
 
-`Selection` Requires selection of desktop, basically turns `emptty` file into `.xinitrc` for Xorg and Wayland. In this case `Exec` is skipped. Possible values are "false" for never using selection, "true" for always showing selection or "always" for showing selection or first option autoselect, if there is no other desktop. Defauls value is false.
+`Selection` Requires selection of desktop, basically turns `emptty` file into `.xinitrc` for Xorg and Wayland. In this case `Exec` is skipped. Possible values are "false" for never using selection, "true" for always showing selection or "auto" for showing selection or first option autoselect, if there is no other desktop. Defauls value is false.
 
 `LoginShell` Defines custom shell to be used to start the session. This allows to start the session with non-interactive shell e.g. `/bin/bash --login`
 

--- a/res/emptty.1
+++ b/res/emptty.1
@@ -207,7 +207,7 @@ file into
 .I .xinitrc
 for Xorg and Wayland. In this case
 .I Exec
-is skipped. Possible values are "false" for never using selection, "true" for always showing selection or "always" for showing selection or first option autoselect, if there is no other desktop. Default value is false.
+is skipped. Possible values are "false" for never using selection, "true" for always showing selection or "auto" for showing selection or first option autoselect, if there is no other desktop. Default value is false.
 .IP LoginShell
 Defines custom shell to be used to start the session. This allows starting the session with non-interactive shell e.g. "/bin/bash --login"
 .IP DesktopNames


### PR DESCRIPTION
Small error in readme and manpage, that points users to an incorrect `Selection` value.