### PR TITLE
Fix typo in SAMPLES.md

### DIFF
--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -94,7 +94,7 @@ exec dbus-launch $@
 #### User-specific
 Create folder custom-sessions as super user
 ```
-$ mkdir -p ~/.config/emptty-custom-sessions/
+$ mkdir -p ~/.config/emptty/custom-sessions
 ```
 
 #### System-wide


### PR DESCRIPTION
Fix user-specific custom-sessions directory path, to match the layout from system-wide's config.  
I also took the liberty to also remove the trailing slash... this can be reverted if you wish.