### PR TITLE
Bugfix/login-retry

### DIFF
--- a/src/sysuser.go
+++ b/src/sysuser.go
@@ -8,10 +8,6 @@ import (
 	"strings"
 )
 
-const (
-	pathUserRetryFile = "/.cache/emptty/login-retry"
-)
-
 // Type sysuser defines default structure of user to easier passing of all values.
 type sysuser struct {
 	username string
@@ -101,9 +97,4 @@ func (u *sysuser) getShell() string {
 		return C.GoString(pwd.pw_shell)
 	}
 	return "/bin/sh"
-}
-
-// Gets path to login retry file
-func (u *sysuser) getLoginRetryPath() string {
-	return u.homedir + pathUserRetryFile
 }

--- a/src/sysuser_test.go
+++ b/src/sysuser_test.go
@@ -2,7 +2,6 @@ package src
 
 import (
 	"os/user"
-	"strings"
 	"testing"
 )
 
@@ -25,10 +24,6 @@ func TestGetSysuser(t *testing.T) {
 
 	if u.gidu32() != 2000 {
 		t.Error("TestGetSysuser: gid32 does not match")
-	}
-
-	if !strings.HasPrefix(u.getLoginRetryPath(), "/dev/null") || !strings.HasSuffix(u.getLoginRetryPath(), pathUserRetryFile) {
-		t.Error("TestGetSysuser: unexpected login retry path")
 	}
 }
 


### PR DESCRIPTION
- feat: use uptime to keep track of the retry count

  Encode system uptime timestamps into the retry file, use these instead of the
  system clock so we are not longer affected by system time drifts.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- refactor: make retry file global and move it to /tmp

  Make the retry file global, since this already assumes we're operating in
  single-user mode with autologin enabled. Also, move it under /tmp and ensure
  it's owned and only accessible by root.

  Signed-off-by: Randolph Sapp <rs@ti.com>