### PR TITLE
Update dinit-service - loginready and rclocal are deprecated

### DIFF
--- a/res/dinit-service
+++ b/res/dinit-service
@@ -3,5 +3,5 @@ command = /etc/dinit.d/scripts/emptty
 restart = true
 smooth-recovery = true
 depends-on = logind
-waits-for = loginready
-waits-for = rclocal
+waits-for = login.target
+waits-for = local.target


### PR DESCRIPTION
Hi !
loginready and rclocal are deprecated  , with those as waits-for , the system was unbootable Replacing them with the supported login.target and local.target fix the issue and made the system bootable again

Full content results as:

```
type = process
command = /etc/dinit.d/scripts/emptty
restart = true
smooth-recovery = true
depends-on = logind
waits-for = login.target
waits-for = local.target
```

This is a need change to make emptty works with dinit .

I've personally made this change on my own machine, testing it on Artix , it works ok

Thank you